### PR TITLE
Fix prefix doubling

### DIFF
--- a/com.go
+++ b/com.go
@@ -362,8 +362,6 @@ func setFlags(flags *flagTracker, main interface{}, prefix string) error {
 			// !embed struct have a field with the same name)?
 			if flagName == "!embed" {
 				newprefix = prefix
-			} else if prefix != "" {
-				newprefix = prefix + "." + flagName
 			} else {
 				newprefix = flagName
 			}

--- a/pflag/com_test.go
+++ b/pflag/com_test.go
@@ -2,6 +2,7 @@ package pflag_test
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -28,4 +29,45 @@ func TestLoadArgsEnvPflag(t *testing.T) {
 		t.Errorf("unexpected value for field 11 (wrapped Duration type)")
 	}
 
+}
+
+func TestNames(t *testing.T) {
+	m := test.NewMyMain()
+	flags := &compflag.FlagSet{pflag.NewFlagSet("tstsimplemain", pflag.ContinueOnError)}
+	err := commandeer.Flags(flags, m)
+	if err != nil {
+		t.Fatalf("getting flags for MyMain: %v", err)
+	}
+	flagNames := flags.Flags()
+	sort.Strings(flagNames)
+	expect := []string{
+		"a-bool",
+		"a-bool-slice",
+		"a-duration",
+		"a-float",
+		"a-int",
+		"a-int-slice",
+		"a-int64",
+		"a-string-slice",
+		"a-uint",
+		"a-uint-slice",
+		"a-uint64",
+		"afloat32",
+		"aint32",
+		"aint8",
+		"aip",
+		"aip-net",
+		"aip-slice",
+		"anint16",
+		"auint16",
+		"auint32",
+		"auint8",
+		"ipmask",
+		"subthing.a-bool",
+		"subthing.recursion.b-bool",
+		"thing",
+	}
+	if !reflect.DeepEqual(expect, flagNames) {
+		t.Fatalf("expected %v but got %v", expect, flagNames)
+	}
 }

--- a/test/test.go
+++ b/test/test.go
@@ -71,13 +71,22 @@ func NewMyMain() *MyMain {
 
 		SubThing: SubThing{
 			SubBool: true,
+			Recursion: Recursion{
+				NestBool: true,
+			},
 		},
 	}
 }
 
 // SubThing exists to test nested structs.
 type SubThing struct {
-	SubBool bool `flag:"a-bool" help:"nested boolean flag"`
+	SubBool   bool      `flag:"a-bool" help:"nested boolean flag"`
+	Recursion Recursion `flag:"recursion"`
+}
+
+// Recursion exists to test multiple levels of nested structs.
+type Recursion struct {
+	NestBool bool `flag:"b-bool" help:"doubly nested boolean flag"`
 }
 
 // Run implements the Runner interface.


### PR DESCRIPTION
Previously when using multiple levels of struct nesting, the prefix would be duplicated.