### PR TITLE
stop automatically generating shorthand for each flag

### DIFF
--- a/com.go
+++ b/com.go
@@ -494,16 +494,6 @@ func (fTr *flagTracker) short(field reflect.StructField, flagName string) (lette
 		fTr.shorts[runeVal] = struct{}{}
 		return short, nil
 	}
-	for _, chr := range flagName {
-		if _, ok := fTr.shorts[chr]; ok {
-			continue
-		}
-		// TODO if the lowercase version of first letter is taken, try upper case and vice versa
-		if unicode.IsLetter(chr) {
-			fTr.shorts[chr] = struct{}{}
-			return string(chr), nil
-		}
-	}
 	return "", nil // no shorthand char available, but that's ok
 }
 

--- a/test/test.go
+++ b/test/test.go
@@ -24,7 +24,7 @@ type MyMain struct {
 	Aint16    int16 `json:"anint16"`
 	Aint32    int32
 	Aint64    int64   `flag:"a-int64" help:"int64 flag"`
-	Afloat    float64 `flag:"a-float" help:"float flag"`
+	Afloat    float64 `flag:"a-float" help:"float flag" short:"f"`
 	Afloat32  float32
 	Auint     uint `flag:"a-uint" help:"uint flag"`
 	Auint8    uint8


### PR DESCRIPTION
it can lead to unstable arguments when adding fields to structs—better
to define them explicitly

fixes #3 