### PR TITLE
Fixing panic when -h is an argument

### DIFF
--- a/com.go
+++ b/com.go
@@ -441,6 +441,9 @@ func (v encodedValue) Set(str string) error {
 }
 
 func (v encodedValue) String() string {
+	if v.encodable == nil {
+		return ""
+	}
 	dat, err := v.MarshalText()
 	if err != nil {
 		panic(err)

--- a/com_test.go
+++ b/com_test.go
@@ -158,6 +158,20 @@ func TestZeroStruct(t *testing.T) {
 	}
 }
 
+func TestZeroStructStdlibFlag(t *testing.T) {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	mm := &test.SimpleMain{}
+	err := Flags(fs, mm)
+	if err != nil {
+		t.Fatalf("setting flags with zero MyMain: %v", err)
+	}
+
+	err = fs.Parse([]string{"-h"})
+	if err != nil && err != flag.ErrHelp {
+		t.Fatalf("parsing help flag: %v", err)
+	}
+}
+
 func TestNonStruct(t *testing.T) {
 	var a int = 4
 	err := Run(&a)


### PR DESCRIPTION
If you are using stdlib Flags, and one of your flags implements TextMarshaler and TextUnmarshaler, commander panics when the -h flag is passed as an argument.